### PR TITLE
Add persistent history logging of presentation URLs to ~/.tomolog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -157,6 +157,10 @@ script
 
 # tomolog temp files
 ####################
+*.jpg
+tmp*
+temp*
+.loglogin
 projection.jpg
 reconstruction.jpg
 web_cam.jpg

--- a/src/tomolog_cli/auth.py
+++ b/src/tomolog_cli/auth.py
@@ -87,6 +87,7 @@ def google_slide(args, token_fname):
             # Replace 'YOUR_PRESENTATION_ID' with a valid one if available
             slides.presentations().get(presentationId=extract_presentation_id(args.presentation_url)).execute()
             log.info("✅ Google Slides API connection verified.")
+            log.info("Presentation URL: %s" % args.presentation_url)
         except Exception as e:
             log.error("❌ Failed to verify Google Slides connection.")
             log.error(str(e))

--- a/src/tomolog_cli/tomolog.py
+++ b/src/tomolog_cli/tomolog.py
@@ -46,6 +46,8 @@
 import os
 import uuid
 import pathlib
+import datetime
+import yaml
 import h5py
 import matplotlib.pyplot as plt
 import numpy as np
@@ -105,6 +107,9 @@ class TomoLog():
         self.num_angle_key      = '/process/acquisition/rotation/num_angles'
         self.rotation_start_key = '/process/acquisition/rotation/start'
         self.date_key           = '/process/acquisition/start_date'
+        self.proposal_key       = '/measurement/sample/experiment/proposal'
+        self.user_name_key      = '/measurement/sample/experimenter/name'
+        self.user_id_key        = '/measurement/sample/experimenter/user_id'
 
     def publish_descr(self, presentation_id, page_id):
         # add here beamline independent bullets
@@ -186,6 +191,7 @@ class TomoLog():
 
         
         presentation_id, page_id = self.init_slide()
+        self.save_history(self.args.presentation_url)
         self.publish_descr(presentation_id, page_id)
         self.publish_note(presentation_id, page_id)
         proj = self.read_raw()
@@ -209,6 +215,26 @@ class TomoLog():
         self.google_slide.create_textbox_with_text(presentation_id, page_id, os.path.basename(
             self.args.file_name)[:-3], 400, 50, 0, 0, 13, 1)
         return presentation_id, page_id
+
+    def save_history(self, presentation_url):
+        history_file = pathlib.Path.home() / '.tomolog'
+        entry = {
+            'date':             datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S'),
+            'presentation_url': presentation_url,
+            'gup':              self.meta.get(self.proposal_key,  [None])[0],
+            'username':         self.meta.get(self.user_name_key, [None])[0],
+            'user_id':          self.meta.get(self.user_id_key,   [None])[0],
+            'beamline':         self.meta.get(self.beamline_key,  [None])[0],
+            'file':             self.args.file_name,
+        }
+        history = []
+        if history_file.exists():
+            with open(history_file) as f:
+                history = yaml.safe_load(f) or []
+        history.append(entry)
+        with open(history_file, 'w') as f:
+            yaml.dump(history, f, default_flow_style=False, allow_unicode=True)
+        log.info('History saved to %s' % history_file)
 
     def read_meta_item(self, template):
         try:

--- a/src/tomolog_cli/tomolog.py
+++ b/src/tomolog_cli/tomolog.py
@@ -220,20 +220,24 @@ class TomoLog():
         history_file = pathlib.Path.home() / '.tomolog'
         entry = {
             'date':             datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S'),
-            'presentation_url': presentation_url,
-            'gup':              self.meta.get(self.proposal_key,  [None])[0],
-            'username':         self.meta.get(self.user_name_key, [None])[0],
-            'user_id':          self.meta.get(self.user_id_key,   [None])[0],
-            'beamline':         self.meta.get(self.beamline_key,  [None])[0],
-            'file':             self.args.file_name,
+            'presentation_url': str(presentation_url),
+            'gup':              str(self.meta.get(self.proposal_key,  [None])[0]),
+            'username':         str(self.meta.get(self.user_name_key, [None])[0]),
+            'user_id':          str(self.meta.get(self.user_id_key,   [None])[0]),
+            'beamline':         str(self.meta.get(self.beamline_key,  [None])[0]),
+            'file':             str(self.args.file_name),
         }
         history = []
         if history_file.exists():
-            with open(history_file) as f:
-                history = yaml.safe_load(f) or []
+            try:
+                with open(history_file) as f:
+                    history = yaml.safe_load(f) or []
+            except yaml.YAMLError:
+                log.warning('Could not parse existing %s, starting fresh' % history_file)
+                history = []
         history.append(entry)
         with open(history_file, 'w') as f:
-            yaml.dump(history, f, default_flow_style=False, allow_unicode=True)
+            yaml.safe_dump(history, f, default_flow_style=False, allow_unicode=True)
         log.info('History saved to %s' % history_file)
 
     def read_meta_item(self, template):


### PR DESCRIPTION
## Add persistent history logging of presentation URLs to `~/.tomolog`

## Summary

This PR adds a persistent history file (`~/.tomolog`) that records every tomolog run, enabling other tools to look up a Google Slides presentation URL by GUP/proposal number. It also improves logging and cleans up the `.gitignore`.

## Changes

### History logging (`tomolog.py`)
- Added a `save_history()` method to the base `TomoLog` class that appends one YAML entry to `~/.tomolog` on every run
- Each entry stores: date/time, GUP/proposal number, username, user badge ID, beamline, HDF5 file path, and presentation URL
- Added three new HDF5 metadata keys:
  - `/measurement/sample/experiment/proposal` (GUP number)
  - `/measurement/sample/experimenter/name` (username)
  - `/measurement/sample/experimenter/user_id` (badge ID)
- All values are cast to plain strings and written with `yaml.safe_dump` to ensure portable YAML output
- Corrupted or legacy `~/.tomolog` files are handled gracefully with a warning instead of a crash
- Since all three beamlines (2-BM, 7-BM, 32-ID) inherit from `TomoLog`, history logging works for all of them with no beamline-specific changes

### Presentation URL logging (`auth.py`)
- The Google Slides presentation URL is now logged at INFO level immediately after the API connection is verified

### `.gitignore`
- Added `*.jpg`, `tmp*`, `temp*`, and `.loglogin` to prevent temporary files from being accidentally committed

## Example output (`~/.tomolog`)

```yaml
- beamline: 2-BM
  date: '2026-03-13 17:13:27'
  file: /data3/2BM/2026-03/Li/stained_star_fish_off_center_5x_Xin_1mm_159.h5
  gup: '1018528'
  presentation_url: https://docs.google.com/presentation/d/.../edit?usp=sharing
  user_id: '206721'
  username: Li
