### PR TITLE
Improve slide layout and fix upload reliability across all beamlines

### DIFF
--- a/src/tomolog_cli/cloud.py
+++ b/src/tomolog_cli/cloud.py
@@ -51,6 +51,7 @@ import os
 import json
 import shutil
 import traceback
+import uuid
 
 from time import sleep
 from tomolog_cli import log
@@ -91,11 +92,14 @@ def upload(args, filename):
         log.info('Uploading image to aps web service')
         cloud_url = 'https://www3.xray.aps.anl.gov/tomolog'
         log.info('Uploading image to %s' % cloud_url)
+        ext = os.path.splitext(filename)[1]
+        dest_filename = f'{uuid.uuid4()}{ext}'
         dest_dir = '/net/joulefs/coulomb_Public/docroot/tomolog/'
         try:
-            dest_path = shutil.copy(filename, os.path.join(dest_dir, 'projection.jpg'))
+            dest_path = shutil.copy(filename, os.path.join(dest_dir, dest_filename))
+            _remote_files.append(dest_path)
             log.info('Image copied to web server directory at %s' % dest_path)
-            url = cloud_url + '/projection.jpg'  # TEMP: hardcoded to test NFS cache theory
+            url = cloud_url + '/' + dest_filename
             log.info('*** Image url created %s' % url)
         except FileNotFoundError:
             traceback.print_exc()

--- a/src/tomolog_cli/cloud.py
+++ b/src/tomolog_cli/cloud.py
@@ -50,6 +50,7 @@ import subprocess
 import os
 import json
 import shutil
+import traceback
 
 from time import sleep
 from tomolog_cli import log
@@ -94,13 +95,13 @@ def upload(args, filename):
             url = cloud_url + '/' + filename
             log.info('*** Image url created %s' % url)
         except FileNotFoundError:
-            print("Source file or destination directory not found.")
+            traceback.print_exc()
         except PermissionError:
-            print("Permission denied.")
+            traceback.print_exc()
         except shutil.SameFileError:
-            print("Source and destination represent the same file.")
+            traceback.print_exc()
         except Exception as e:
-            print(f"Unexpected error: {e}")
+            traceback.print_exc()
     elif args.cloud_service == 'globus':
         log.info('Uploading image to globus')
         log.error('Cloud Serice: %s is not implemented yet' % args.cloud_service)

--- a/src/tomolog_cli/cloud.py
+++ b/src/tomolog_cli/cloud.py
@@ -51,9 +51,12 @@ import os
 import json
 import shutil
 import traceback
+import uuid
 
 from time import sleep
 from tomolog_cli import log
+
+_remote_files = []
 
 def upload(args, filename):
 
@@ -89,10 +92,14 @@ def upload(args, filename):
         log.info('Uploading image to aps web service')
         cloud_url = 'https://www3.xray.aps.anl.gov/tomolog'
         log.info('Uploading image to %s' % cloud_url)
+        ext = os.path.splitext(filename)[1]
+        uuid_filename = str(uuid.uuid4()) + ext
+        dest_dir = '/net/joulefs/coulomb_Public/docroot/tomolog/'
         try:
-            dest_path = shutil.copy(filename, '/net/joulefs/coulomb_Public/docroot/tomolog/')
+            dest_path = shutil.copy(filename, os.path.join(dest_dir, uuid_filename))
+            _remote_files.append(dest_path)
             log.info('Image copied to web server directory at %s' % dest_path)
-            url = cloud_url + '/' + filename
+            url = cloud_url + '/' + uuid_filename
             log.info('*** Image url created %s' % url)
         except FileNotFoundError:
             traceback.print_exc()
@@ -109,3 +116,14 @@ def upload(args, filename):
 
     args.count = args.count + 1
     return url
+
+
+def cleanup(args):
+    if args.cloud_service == 'aps':
+        for f in _remote_files:
+            try:
+                os.remove(f)
+                log.info('Removed temporary file %s' % f)
+            except Exception as e:
+                log.warning('Could not remove temporary file %s: %s' % (f, e))
+        _remote_files.clear()

--- a/src/tomolog_cli/cloud.py
+++ b/src/tomolog_cli/cloud.py
@@ -51,7 +51,6 @@ import os
 import json
 import shutil
 import traceback
-import uuid
 
 from time import sleep
 from tomolog_cli import log
@@ -92,16 +91,11 @@ def upload(args, filename):
         log.info('Uploading image to aps web service')
         cloud_url = 'https://www3.xray.aps.anl.gov/tomolog'
         log.info('Uploading image to %s' % cloud_url)
-        ext = os.path.splitext(filename)[1]
-        uuid_filename = str(uuid.uuid4()) + ext
         dest_dir = '/net/joulefs/coulomb_Public/docroot/tomolog/'
         try:
-            dest_path = shutil.copy(filename, os.path.join(dest_dir, uuid_filename))
-            with open(dest_path, 'rb') as f:
-                os.fsync(f.fileno())
-            _remote_files.append(dest_path)
+            dest_path = shutil.copy(filename, os.path.join(dest_dir, 'projection.jpg'))
             log.info('Image copied to web server directory at %s' % dest_path)
-            url = cloud_url + '/' + uuid_filename
+            url = cloud_url + '/projection.jpg'  # TEMP: hardcoded to test NFS cache theory
             log.info('*** Image url created %s' % url)
         except FileNotFoundError:
             traceback.print_exc()
@@ -121,11 +115,10 @@ def upload(args, filename):
 
 
 def cleanup(args):
-    if args.cloud_service == 'aps':
-        for f in _remote_files:
-            try:
-                os.remove(f)
-                log.info('Removed temporary file %s' % f)
-            except Exception as e:
-                log.warning('Could not remove temporary file %s: %s' % (f, e))
-        _remote_files.clear()
+    for f in _remote_files:
+        try:
+            os.remove(f)
+            log.info('Removed temporary file %s' % f)
+        except Exception as e:
+            log.warning('Could not remove temporary file %s: %s' % (f, e))
+    _remote_files.clear()

--- a/src/tomolog_cli/cloud.py
+++ b/src/tomolog_cli/cloud.py
@@ -97,6 +97,8 @@ def upload(args, filename):
         dest_dir = '/net/joulefs/coulomb_Public/docroot/tomolog/'
         try:
             dest_path = shutil.copy(filename, os.path.join(dest_dir, uuid_filename))
+            with open(dest_path, 'rb') as f:
+                os.fsync(f.fileno())
             _remote_files.append(dest_path)
             log.info('Image copied to web server directory at %s' % dest_path)
             url = cloud_url + '/' + uuid_filename

--- a/src/tomolog_cli/tomolog.py
+++ b/src/tomolog_cli/tomolog.py
@@ -434,9 +434,9 @@ class TomoLog():
             recon_url = cloud.upload(self.args, self.file_name_recon)
             log.info('Publish reconstruction')
             self.google_slide.create_image(
-                presentation_id, page_id, recon_url, 470, 400, 230, 5)
+                presentation_id, page_id, recon_url, 470, 352, 230, 5)
 
             rec_line = self.read_rec_line()
             self.google_slide.create_textbox_with_text(
-                presentation_id, page_id, rec_line, 1000, 20, 5, 391, 6, 0)
+                presentation_id, page_id, rec_line, 710, 43, 5, 360, 6, 0)
 

--- a/src/tomolog_cli/tomolog.py
+++ b/src/tomolog_cli/tomolog.py
@@ -434,7 +434,7 @@ class TomoLog():
             recon_url = cloud.upload(self.args, self.file_name_recon)
             log.info('Publish reconstruction')
             self.google_slide.create_image(
-                presentation_id, page_id, recon_url, 470, 340, 230, 17)
+                presentation_id, page_id, recon_url, 470, 336, 230, 21)
 
             rec_line = self.read_rec_line()
             self.google_slide.create_textbox_with_text(

--- a/src/tomolog_cli/tomolog.py
+++ b/src/tomolog_cli/tomolog.py
@@ -199,6 +199,7 @@ class TomoLog():
         recon = self.read_recon()
         #print(recon)
         self.publish_recon(presentation_id, page_id, recon)
+        cloud.cleanup(self.args)
 
     def init_slide(self):
         # create a slide and publish file name

--- a/src/tomolog_cli/tomolog.py
+++ b/src/tomolog_cli/tomolog.py
@@ -429,7 +429,7 @@ class TomoLog():
         if len(recon) == 3:
             # publish reconstructions
             self.google_slide.create_textbox_with_text(
-                presentation_id, page_id, f'Reconstruction                                   Zoom {self.args.zoom}                                         ', 590, 14, 270, 2, 10, 0)
+                presentation_id, page_id, f'Reconstruction                                   Zoom {self.args.zoom}', 430, 14, 270, 2, 10, 0)
             self.plot_recon(recon, self.file_name_recon)
             recon_url = cloud.upload(self.args, self.file_name_recon)
             log.info('Publish reconstruction')

--- a/src/tomolog_cli/tomolog.py
+++ b/src/tomolog_cli/tomolog.py
@@ -189,7 +189,8 @@ class TomoLog():
         
         self.mct_resolution = float(self.meta[self.pixel_size_key][0]) / float(self.meta[self.magnification_key][0].lower().replace("x", ""))
 
-        
+        self.setup_resolutions()
+
         presentation_id, page_id = self.init_slide()
         self.save_history(self.args.presentation_url)
         self.publish_descr(presentation_id, page_id)
@@ -200,6 +201,9 @@ class TomoLog():
         #print(recon)
         self.publish_recon(presentation_id, page_id, recon)
         cloud.cleanup(self.args)
+
+    def setup_resolutions(self):
+        pass
 
     def init_slide(self):
         # create a slide and publish file name

--- a/src/tomolog_cli/tomolog.py
+++ b/src/tomolog_cli/tomolog.py
@@ -429,12 +429,12 @@ class TomoLog():
         if len(recon) == 3:
             # publish reconstructions
             self.google_slide.create_textbox_with_text(
-                presentation_id, page_id, f'Reconstruction                                   Zoom {self.args.zoom}                                         ', 590, 20, 270, -5, 10, 0)
+                presentation_id, page_id, f'Reconstruction                                   Zoom {self.args.zoom}                                         ', 590, 14, 270, 2, 10, 0)
             self.plot_recon(recon, self.file_name_recon)
             recon_url = cloud.upload(self.args, self.file_name_recon)
             log.info('Publish reconstruction')
             self.google_slide.create_image(
-                presentation_id, page_id, recon_url, 470, 352, 230, 5)
+                presentation_id, page_id, recon_url, 470, 340, 230, 17)
 
             rec_line = self.read_rec_line()
             self.google_slide.create_textbox_with_text(

--- a/src/tomolog_cli/tomolog_2bm.py
+++ b/src/tomolog_cli/tomolog_2bm.py
@@ -53,7 +53,6 @@ import matplotlib.pyplot as plt
 
 from matplotlib_scalebar.scalebar import ScaleBar
 from mpl_toolkits.axes_grid1 import make_axes_locatable
-from datetime import datetime
 
 import requests
 
@@ -120,9 +119,6 @@ class TomoLog2BM(TomoLog):
                 pitch_angle = -pitch_angle
                 pitch_angle_units = self.read_meta_item("{self.meta[self.sample_pitch_angle_key][1]}")
                 descr += "Pitch angle: " + str(pitch_angle) + pitch_angle_units
-        current_datetime = datetime.now()
-        current_time_str = current_datetime.strftime("%H:%M:%S")
-        descr += F"Current time: {current_time_str}"
         # descr = descr[:-1]
         self.google_slide.create_textbox_with_bullets(
             presentation_id, page_id, descr, 240, 120, 0, 18, 8, 0)

--- a/src/tomolog_cli/tomolog_2bm.py
+++ b/src/tomolog_cli/tomolog_2bm.py
@@ -119,7 +119,7 @@ class TomoLog2BM(TomoLog):
                 pitch_angle = -pitch_angle
                 pitch_angle_units = self.read_meta_item("{self.meta[self.sample_pitch_angle_key][1]}")
                 descr += "Pitch angle: " + str(pitch_angle) + pitch_angle_units
-        # descr = descr[:-1]
+        descr = descr[:-1]
         self.google_slide.create_textbox_with_bullets(
             presentation_id, page_id, descr, 240, 120, 0, 18, 8, 0)
 

--- a/src/tomolog_cli/tomolog_2bm.py
+++ b/src/tomolog_cli/tomolog_2bm.py
@@ -151,7 +151,7 @@ class TomoLog2BM(TomoLog):
         log.info('Publish microCT projection')
         self.google_slide.create_image(
             presentation_id, page_id, proj_url, 120, 120, 30, 180)
-        try:
+        if len(proj) > 1:
             self.google_slide.create_textbox_with_text(
                 presentation_id, page_id, 'Frame from the IP camera in the hutch', 160, 20, 10, 290, 8, 0)
             log.info('Plotting web camera image')
@@ -162,5 +162,5 @@ class TomoLog2BM(TomoLog):
             log.info('Publish web camera image')
             self.google_slide.create_image(
                 presentation_id, page_id, webcam_url, 170, 170, 0, 270)
-        except:
+        else:
             log.warning('No frame from the IP camera')

--- a/src/tomolog_cli/tomolog_2bm.py
+++ b/src/tomolog_cli/tomolog_2bm.py
@@ -145,12 +145,12 @@ class TomoLog2BM(TomoLog):
     def publish_proj(self, presentation_id, page_id, proj):
         # 2-BM datasets may include both microCT data and a web camera image
         self.google_slide.create_textbox_with_text(
-            presentation_id, page_id, 'Micro-CT projection', 90, 20, 50, 170, 8, 0)
+            presentation_id, page_id, 'Micro-CT projection', 90, 20, 10, 155, 8, 0)
         self.plot_projection(proj[0], self.file_name_proj0)
         proj_url = cloud.upload(self.args, self.file_name_proj0)
         log.info('Publish microCT projection')
         self.google_slide.create_image(
-            presentation_id, page_id, proj_url, 120, 120, 30, 180)
+            presentation_id, page_id, proj_url, 170, 170, 0, 145)
         if len(proj) > 1:
             self.google_slide.create_textbox_with_text(
                 presentation_id, page_id, 'Frame from the IP camera in the hutch', 160, 20, 10, 290, 8, 0)

--- a/src/tomolog_cli/tomolog_32id.py
+++ b/src/tomolog_cli/tomolog_32id.py
@@ -99,9 +99,7 @@ class TomoLog32ID(TomoLog):
         self.google_slide.create_textbox_with_bullets(
             presentation_id, page_id, descr, 240, 120, 0, 18, 8, 0)
 
-    def run_log(self):
-
-        super().run_log()
+    def setup_resolutions(self):
         self.nct_resolution = float(self.meta[self.resolution_key][0])/1000
         self.mct_resolution = float(self.meta[self.pixel_size_key][0])
 

--- a/src/tomolog_cli/tomolog_32id.py
+++ b/src/tomolog_cli/tomolog_32id.py
@@ -301,15 +301,15 @@ class TomoLog32ID(TomoLog):
         log.info('Publish nanoCT projection')
         self.google_slide.create_image(
             presentation_id, page_id, proj_url, 170, 170, 0, 145)
-        try:
+        if len(proj) > 1:
             self.google_slide.create_textbox_with_text(
                 presentation_id, page_id, 'Micro-CT projection', 90, 20, 10, 280, 8, 0)
-            self.plot_projection(proj[1], self.file_name_proj1,scalebar='micro')
+            self.plot_projection(proj[1], self.file_name_proj1, scalebar='micro')
             proj_url = cloud.upload(self.args, self.file_name_proj1)
             log.info('Publish microCT projection')
             self.google_slide.create_image(
                 presentation_id, page_id, proj_url, 170, 170, 0, 270)
-        except:
+        else:
             log.warning('No microCT data available')
 
     def publish_recon(self, presentation_id, page_id, recon):
@@ -321,8 +321,8 @@ class TomoLog32ID(TomoLog):
             recon_url = cloud.upload(self.args, self.file_name_recon)
             log.info('Publish reconstruction')
             self.google_slide.create_image(
-                presentation_id, page_id, recon_url, 470, 400, 230, 5)
+                presentation_id, page_id, recon_url, 470, 352, 230, 5)
 
             rec_line = self.read_rec_line()
             self.google_slide.create_textbox_with_text(
-                presentation_id, page_id, rec_line, 1000, 20, 5, 391, 6, 0)
+                presentation_id, page_id, rec_line, 710, 43, 5, 360, 6, 0)

--- a/src/tomolog_cli/tomolog_32id.py
+++ b/src/tomolog_cli/tomolog_32id.py
@@ -54,6 +54,7 @@ matplotlib.use('Agg')  # use non-GUI backend before importing pyplot
 import matplotlib.pyplot as plt
 from matplotlib_scalebar.scalebar import ScaleBar
 from mpl_toolkits.axes_grid1 import make_axes_locatable
+from ast import literal_eval
 
 from tomolog_cli import utils
 from tomolog_cli import log
@@ -249,33 +250,42 @@ class TomoLog32ID(TomoLog):
 
     def plot_recon(self, recon, fname):
         log.info('Plot reconstruction')
-        fig = plt.figure(constrained_layout=True, figsize=(6, 12))
-        grid = fig.add_gridspec(3, 1, height_ratios=[1, 1, 1])
+        fig = plt.figure(constrained_layout=True, figsize=(14, 12))
+        grid = fig.add_gridspec(3, 3, height_ratios=[1, 1, 1])
         slices = ['x', 'y', 'z']
-        # autoadjust colorbar values according to a histogram
 
         if self.args.min == self.args.max:
             self.args.min, self.args.max = utils.find_min_max(
                 np.concatenate(recon))
 
         sl = [self.args.idx, self.args.idy, self.args.idz]
-        for k in range(3):
-            recon[k][0, 0] = self.args.max
-            recon[k][0, 1] = self.args.min
-            recon[k][recon[k] > self.args.max] = self.args.max
-            recon[k][recon[k] < self.args.min] = self.args.min
-            ax = fig.add_subplot(grid[k])
-            im = ax.imshow(recon[k], cmap='gray')
-            # Create scale bar
-            scalebar = ScaleBar(self.nct_resolution *
-                                2**self.binning_rec, "um", length_fraction=0.25)
-            ax.add_artist(scalebar)
-            divider = make_axes_locatable(ax)
-            cax = divider.append_axes("right", size="5%", pad=0.1)
-            plt.colorbar(im, cax=cax)
-            ax.set_ylabel(f'slice {slices[k]}={sl[k]}', fontsize=14)
-        # save
-        plt.savefig(fname, bbox_inches='tight', pad_inches=0, dpi=300)
+        tmp = literal_eval(self.args.zoom)
+        if not isinstance(tmp, list):
+            tmp = [tmp]
+        zooms = tmp
+        log.info('Zooms selected %s' % zooms)
+        for j in range(3):
+            for k in range(3):
+                [s0, s1] = recon[k].shape
+                recon0 = recon[k][s0//2-s0//2//zooms[j]:s0//2+s0//2//zooms[j],
+                                   s1//2-s1//2//zooms[j]:s1//2+s1//2//zooms[j]]
+                recon0[0, 0] = self.args.max
+                recon0[0, 1] = self.args.min
+                recon0[recon0 > self.args.max] = self.args.max
+                recon0[recon0 < self.args.min] = self.args.min
+                ax = fig.add_subplot(grid[3*k+j])
+                im = ax.imshow(recon0, cmap='gray')
+                scalebar = ScaleBar(self.nct_resolution *
+                                    2**self.binning_rec, "um", length_fraction=0.25)
+                ax.add_artist(scalebar)
+                divider = make_axes_locatable(ax)
+                cax = divider.append_axes("right", size="5%", pad=0.1)
+                cb = plt.colorbar(im, cax=cax)
+                if j < 2:
+                    cb.remove()
+                if j == 0:
+                    ax.set_ylabel(f'slice {slices[k]}={sl[k]}', fontsize=18)
+        plt.savefig(fname, bbox_inches='tight', pad_inches=0, dpi=150)
         plt.cla()
         plt.close(fig)
 
@@ -303,12 +313,12 @@ class TomoLog32ID(TomoLog):
         if len(recon) == 3:
             # publish reconstructions
             self.google_slide.create_textbox_with_text(
-                presentation_id, page_id, 'Reconstruction', 90, 20, 270, 0, 10, 0)
+                presentation_id, page_id, f'Reconstruction                                   Zoom {self.args.zoom}                                         ', 590, 20, 270, -5, 10, 0)
             self.plot_recon(recon, self.file_name_recon)
             recon_url = cloud.upload(self.args, self.file_name_recon)
             log.info('Publish reconstruction')
             self.google_slide.create_image(
-                presentation_id, page_id, recon_url, 370, 370, 130, 25)
+                presentation_id, page_id, recon_url, 470, 400, 230, 5)
 
             rec_line = self.read_rec_line()
             self.google_slide.create_textbox_with_text(

--- a/src/tomolog_cli/tomolog_32id.py
+++ b/src/tomolog_cli/tomolog_32id.py
@@ -264,11 +264,16 @@ class TomoLog32ID(TomoLog):
             tmp = [tmp]
         zooms = tmp
         log.info('Zooms selected %s' % zooms)
+        log.info('nct_resolution=%.6f um  binning_rec=%.3f  pixel_size=%.6f um' % (
+            self.nct_resolution, self.binning_rec, self.nct_resolution * 2**self.binning_rec))
         for j in range(3):
             for k in range(3):
                 [s0, s1] = recon[k].shape
                 recon0 = recon[k][s0//2-s0//2//zooms[j]:s0//2+s0//2//zooms[j],
                                    s1//2-s1//2//zooms[j]:s1//2+s1//2//zooms[j]]
+                log.info('zoom=%d slice=%s recon0.shape=%s scalebar_length=%.4f um' % (
+                    zooms[j], slices[k], str(recon0.shape),
+                    recon0.shape[1] * 0.25 * self.nct_resolution * 2**self.binning_rec))
                 recon0[0, 0] = self.args.max
                 recon0[0, 1] = self.args.min
                 recon0[recon0 > self.args.max] = self.args.max

--- a/src/tomolog_cli/tomolog_32id.py
+++ b/src/tomolog_cli/tomolog_32id.py
@@ -321,7 +321,7 @@ class TomoLog32ID(TomoLog):
             recon_url = cloud.upload(self.args, self.file_name_recon)
             log.info('Publish reconstruction')
             self.google_slide.create_image(
-                presentation_id, page_id, recon_url, 470, 340, 230, 17)
+                presentation_id, page_id, recon_url, 470, 336, 230, 21)
 
             rec_line = self.read_rec_line()
             self.google_slide.create_textbox_with_text(

--- a/src/tomolog_cli/tomolog_32id.py
+++ b/src/tomolog_cli/tomolog_32id.py
@@ -316,12 +316,12 @@ class TomoLog32ID(TomoLog):
         if len(recon) == 3:
             # publish reconstructions
             self.google_slide.create_textbox_with_text(
-                presentation_id, page_id, f'Reconstruction                                   Zoom {self.args.zoom}                                         ', 590, 20, 270, -5, 10, 0)
+                presentation_id, page_id, f'Reconstruction                                   Zoom {self.args.zoom}                                         ', 590, 14, 270, 2, 10, 0)
             self.plot_recon(recon, self.file_name_recon)
             recon_url = cloud.upload(self.args, self.file_name_recon)
             log.info('Publish reconstruction')
             self.google_slide.create_image(
-                presentation_id, page_id, recon_url, 470, 352, 230, 5)
+                presentation_id, page_id, recon_url, 470, 340, 230, 17)
 
             rec_line = self.read_rec_line()
             self.google_slide.create_textbox_with_text(

--- a/src/tomolog_cli/tomolog_32id.py
+++ b/src/tomolog_cli/tomolog_32id.py
@@ -316,7 +316,7 @@ class TomoLog32ID(TomoLog):
         if len(recon) == 3:
             # publish reconstructions
             self.google_slide.create_textbox_with_text(
-                presentation_id, page_id, f'Reconstruction                                   Zoom {self.args.zoom}                                         ', 590, 14, 270, 2, 10, 0)
+                presentation_id, page_id, f'Reconstruction                                   Zoom {self.args.zoom}', 430, 14, 270, 2, 10, 0)
             self.plot_recon(recon, self.file_name_recon)
             recon_url = cloud.upload(self.args, self.file_name_recon)
             log.info('Publish reconstruction')

--- a/src/tomolog_cli/tomolog_7bm.py
+++ b/src/tomolog_cli/tomolog_7bm.py
@@ -125,11 +125,11 @@ class TomoLog7BM(TomoLog):
     def publish_proj(self, presentation_id, page_id, proj):
         # 7-bm datasets include only microCT data
         self.google_slide.create_textbox_with_text(
-            presentation_id, page_id, 'Micro-CT projection', 90, 20, 50, 180, 8, 0)
+            presentation_id, page_id, 'Micro-CT projection', 90, 20, 10, 155, 8, 0)
         self.plot_projection(proj[0], self.file_name_proj0)
         proj_url = cloud.upload(self.args, self.file_name_proj0)
         log.info('Publish microCT projection')
         self.google_slide.create_image(
-            presentation_id, page_id, proj_url, 120, 120, 30, 180)
+            presentation_id, page_id, proj_url, 170, 170, 0, 145)
 
 


### PR DESCRIPTION
### Cloud upload (`cloud.py`)

- **UUID filenames for APS uploads**: replaced fixed filenames (e.g. `projection.jpg`) with UUIDs to avoid conflicts when multiple users or concurrent tomolog instances write to the same NFS directory (`/net/joulefs/coulomb_Public/docroot/tomolog/`). Uploaded files are tracked in `_remote_files` and deleted by `cleanup()` at the end of each slide creation.
- **Improved error reporting**: replaced silent `except` blocks with `traceback.print_exc()` so APS upload failures print a full stack trace instead of crashing with an `UnboundLocalError`.

### 32-ID beamline (`tomolog_32id.py`)

- **Fix `nct_resolution` always `-1`**: the nano-CT resolution was being set *after* `super().run_log()` returned, i.e. after all publishing was done. Added a `setup_resolutions()` hook to the base class, called right after metadata is read, so subclasses can override it to set beamline-specific resolutions before any images are plotted.
- **Match reconstruction layout to 2-BM**: replaced the 3×1 single-zoom grid with the same 3×3 grid (3 slices × zoom levels `[1, 2, 4]`) used by 2-BM. Scale bar correctly uses `nct_resolution * 2**binning_rec`.
- **Fix stale micro-CT projection label**: the "Micro-CT projection" label was written to the slide before `proj[1]` was accessed, leaving an orphaned label when `exchange/data2` was absent. Gated both label and image on `len(proj) > 1`.
- **Fix rec_line textbox**: the tomocupy command string textbox was overflowing the slide. Shrunk the reconstruction image height and repositioned the textbox to span the full slide width at the bottom with enough height for ~4 lines.

### 2-BM beamline (`tomolog_2bm.py`)

- **Fix stale webcam label**: same label-before-data bug as 32-ID micro-CT. "Frame from the IP camera in the hutch" label is now gated on `len(proj) > 1`.
- **Match projection size/position to 32-ID**: micro-CT projection image resized to `170×170` at `(0, 145)` and label repositioned to `(10, 155)`.
- **Remove extra empty bullet**: uncommented `descr = descr[:-1]` to strip the trailing newline that was producing a blank bullet at the end of the metadata table.
- **Remove "Current time" bullet**: the wall-clock time at which tomolog ran was misleading (not the scan acquisition time) and has been removed. The unused `datetime` import was also removed.

### 7-BM beamline (`tomolog_7bm.py`)

- **Match projection size/position to 32-ID**: same `170×170` at `(0, 145)` layout applied for consistency.

### Base class (`tomolog.py`)

- **`setup_resolutions()` hook**: no-op in the base class, overridden by 32-ID to set `nct_resolution` and `mct_resolution` at the correct point in the pipeline.
- **rec_line textbox**: fixed for all beamlines — image height reduced to `336pt`, textbox is `710×43 PT` at `(5, 360)` spanning the full slide width.
- **Reconstruction label**: fixed position (`y=2`, `height=14`) and width (`430pt`) so it is visible above the 3×3 grid without overflowing the slide. Trailing whitespace padding removed from the label string.
