### PR TITLE
This PR collects four commits adding support for the new tomocupy h5nolinks default output, handling split data/analysis path layouts (common at beamline storage tiers like /gdata vs /data), making the batch mode survive transient failures, and adding the Eurotherm furnace-temperature bullet for 2-BM thermal experiments.

### DIFF
--- a/src/tomolog_cli/__main__.py
+++ b/src/tomolog_cli/__main__.py
@@ -72,6 +72,7 @@ def run_log(args):
     # args.count = args.count + 1
     config.write(args.config, args, sections=config.PARAMS)
     log.warning('publication end')
+    log.info('presentation-url: %s' % args.presentation_url)
     
 def main():
 

--- a/src/tomolog_cli/__main__.py
+++ b/src/tomolog_cli/__main__.py
@@ -54,14 +54,17 @@ def run_log(args):
                 args.file_name = top + fname
                 log.warning("  *** file %d/%d;  %s" % (index, len(h5_file_list_sorted), fname))
                 index += 1
-                if args.beamline == '32-id':
-                    TomoLog32ID(args).run_log()
-                elif args.beamline == '2-bm':
-                    TomoLog2BM(args).run_log()
-                elif args.beamline == '7-bm':
-                    TomoLog7BM(args).run_log()
-                else:
-                    TomoLog(args).run_log()
+                try:
+                    if args.beamline == '32-id':
+                        TomoLog32ID(args).run_log()
+                    elif args.beamline == '2-bm':
+                        TomoLog2BM(args).run_log()
+                    elif args.beamline == '7-bm':
+                        TomoLog7BM(args).run_log()
+                    else:
+                        TomoLog(args).run_log()
+                except Exception as e:
+                    log.error("Failed to publish %s: %s — continuing batch", fname, e)
                 time.sleep(20)
 
         else:

--- a/src/tomolog_cli/config.py
+++ b/src/tomolog_cli/config.py
@@ -155,6 +155,11 @@ SECTIONS['general'] = {
         'type': str,
         'help': "Reconstruction save format. 'auto' picks based on what's on disk: single-file h5 if <base>_rec.h5 exists, else tiff folder. Set explicitly to force a layout.",
         'choices': ['auto', 'tiff', 'h5', 'h5nolinks']},
+    'analysis-path': {
+        'default': None,
+        'type': Path,
+        'help': "Override directory where reconstructions (<base>_rec.h5 / <base>_rec/ + <base>_rec_line.txt) are located. Defaults to <dirname_of_raw>_rec/.",
+        'metavar': 'PATH'},
     'magnification': {
         'type': float,
         'default': -1,

--- a/src/tomolog_cli/config.py
+++ b/src/tomolog_cli/config.py
@@ -151,10 +151,10 @@ SECTIONS['general'] = {
         'default': 8,
         'help': "Number of threads to read tiff"},
     'save-format': {
-        'default': 'tiff',
+        'default': 'auto',
         'type': str,
-        'help': "Reconstruction save format",
-        'choices': ['tiff','h5']},    
+        'help': "Reconstruction save format. 'auto' picks based on what's on disk: single-file h5 if <base>_rec.h5 exists, else tiff folder. Set explicitly to force a layout.",
+        'choices': ['auto', 'tiff', 'h5', 'h5nolinks']},
     'magnification': {
         'type': float,
         'default': -1,

--- a/src/tomolog_cli/tomolog.py
+++ b/src/tomolog_cli/tomolog.py
@@ -151,13 +151,57 @@ class TomoLog():
         else:
             pass
 
+    def _rec_dir(self):
+        """Directory holding reconstructions for the current raw file.
+
+        Defaults to '<dirname_of_raw>_rec' (the tomocupy convention).
+        Overridden by --analysis-path when the recons live elsewhere
+        (e.g. /gdata/.../analysis/ while raw data is at /gdata/.../data/).
+        """
+        if self.args.analysis_path is not None:
+            return str(self.args.analysis_path)
+        return os.path.dirname(self.args.file_name) + '_rec'
+
+    def _recon_layout(self):
+        """Resolve the reconstruction layout — 'h5', 'tiff', or None.
+
+        If --save-format is 'auto' (default), inspect the filesystem and pick:
+          - 'h5'   when <rec_dir>/<base>_rec.h5 exists (h5/h5nolinks output)
+          - 'tiff' when <rec_dir>/<base>_rec/ directory exists
+          - None   when neither is present (caller logs a warning)
+        If --save-format is set explicitly, honor it. 'h5' and 'h5nolinks'
+        both map to the single-h5-file reader (h5py reads them identically).
+        """
+        basename = os.path.basename(self.args.file_name)[:-3]
+        rec_dir = self._rec_dir()
+        h5_path = f'{rec_dir}/{basename}_rec.h5'
+        tiff_dir = f'{rec_dir}/{basename}_rec'
+
+        if self.args.save_format == 'auto':
+            if os.path.exists(h5_path):
+                log.info(f'Detected reconstruction layout: h5 ({h5_path})')
+                return 'h5'
+            if os.path.isdir(tiff_dir):
+                log.info(f'Detected reconstruction layout: tiff ({tiff_dir})')
+                return 'tiff'
+            log.warning(f'No reconstruction found at {h5_path} or {tiff_dir}')
+            return None
+        if self.args.save_format in ('h5', 'h5nolinks'):
+            return 'h5'
+        return 'tiff'
+
     def read_rec_line(self):
-        line = None
+        line = ''
         try:
             log.info('Publish reconstruction command line')
             basename = os.path.basename(self.args.file_name)[:-3]
-            dirname = os.path.dirname(self.args.file_name)
-            with open(f'{dirname}_rec/{basename}_rec/rec_line.txt', 'r') as fid:
+            rec_dir = self._rec_dir()
+            layout = self._recon_layout()
+            if layout == 'h5':
+                path = f'{rec_dir}/{basename}_rec_line.txt'
+            else:
+                path = f'{rec_dir}/{basename}_rec/rec_line.txt'
+            with open(path, 'r') as fid:
                 line = fid.readlines()[0]
         except:
             log.warning('Skipping the command line for reconstruction')
@@ -268,32 +312,46 @@ class TomoLog():
         binning = int(self.meta[self.binning_key][0])
         recon = []
 
-        if self.args.save_format == 'h5':
-            fname  = os.path.dirname(self.args.file_name)+'_rec/'+os.path.basename(self.args.file_name)[:-3]+'_rec.h5'
-            with h5py.File(fname,'r') as fid:
-                data = fid['exchange/recon']
-                h,w = data.shape[:2]
-                if self.args.idz == -1:
-                    self.args.idz = int(h//2)
-                if self.args.idy == -1:
-                    self.args.idy = int(w//2)
-                if self.args.idx == -1:
-                    self.args.idx = int(w//2)
-                if self.double_fov == True:
-                    binning_rec = np.log2(width//(w//2))
-                else:
-                    binning_rec = np.log2(width//(w))
-                x = data[:,:,self.args.idx]
-                y = data[:,self.args.idy]
-                z = data[self.args.idz]
+        layout = self._recon_layout()
+        if layout is None:
+            return recon
+
+        if layout == 'h5':
+            basename = os.path.basename(self.args.file_name)[:-3]
+            fname = f'{self._rec_dir()}/{basename}_rec.h5'
+            try:
+                with h5py.File(fname, 'r') as fid:
+                    data = fid['exchange/data']
+                    h, w = data.shape[:2]
+                    if self.args.idz == -1:
+                        self.args.idz = int(h//2)
+                    if self.args.idy == -1:
+                        self.args.idy = int(w//2)
+                    if self.args.idx == -1:
+                        self.args.idx = int(w//2)
+                    if self.double_fov == True:
+                        binning_rec = np.log2(width//(w//2))
+                    else:
+                        binning_rec = np.log2(width//(w))
+                    x = data[:, :, self.args.idx]
+                    y = data[:, self.args.idy]
+                    z = data[self.args.idz]
+                recon = [x, y, z]
+                self.binning_rec = binning_rec
+            except FileNotFoundError:
+                log.error(f'Reconstruction h5 file missing: {fname}')
+                log.warning('Skipping reconstruction')
+            except KeyError:
+                log.error(f'/exchange/data not found in {fname} (h5sino is not supported for slicing)')
+                log.warning('Skipping reconstruction')
         else:
             try:
                 basename = os.path.basename(self.args.file_name)[:-3]
-                dirname = os.path.dirname(self.args.file_name)
+                rec_dir = self._rec_dir()
                 # set the correct prefix to find the reconstructions
                 rec_prefix = 'recon'
 
-                top = os.path.join(dirname+'_rec', basename+'_rec')
+                top = os.path.join(rec_dir, basename+'_rec')
                 tiff_file_list = sorted(
                     list(filter(lambda x: x.endswith(('.tif', '.tiff')), os.listdir(top))))
                 z_start = int(tiff_file_list[0].split('.')[0].split('_')[1])
@@ -319,7 +377,7 @@ class TomoLog():
                     self.args.idx = int(w//2)-int(w//32)
 
                 z = utils.read_tiff(
-                    f'{dirname}_rec/{basename}_rec/{rec_prefix}_{self.args.idz:05}.tiff').copy()
+                    f'{rec_dir}/{basename}_rec/{rec_prefix}_{self.args.idz:05}.tiff').copy()
                 
                 # read x,y slices by lines
                 y = np.zeros((h, w), dtype='float32')
@@ -330,7 +388,7 @@ class TomoLog():
                 lchunk = int(np.ceil((z_end-z_start)/nthreads))
                 lchunk = np.minimum(lchunk, np.int32(z_end-z_start-np.arange(nthreads)*lchunk))  # chunk sizes
                 for k in range(nthreads):
-                    read_proc = Thread(target=utils.read_tiff_part, args=(self.args, f'{dirname}_rec/{basename}_rec/{rec_prefix}', x, y, z_start, k*lchunk[0], lchunk[k]))
+                    read_proc = Thread(target=utils.read_tiff_part, args=(self.args, f'{rec_dir}/{basename}_rec/{rec_prefix}', x, y, z_start, k*lchunk[0], lchunk[k]))
                     threads.append(read_proc)
                     read_proc.start()
                 for th in threads:

--- a/src/tomolog_cli/tomolog_2bm.py
+++ b/src/tomolog_cli/tomolog_2bm.py
@@ -102,8 +102,8 @@ class TomoLog2BM(TomoLog):
             "Sample Y: {self.meta[self.sample_y_key][0]:.02f} {self.meta[self.sample_y_key][1]}")
         descr += self.read_meta_item(
             "Propagation dist.: {self.meta[self.propogation_distance_key][0]:.02f} {self.meta[self.propogation_distance_key][1]}")
-        # descr += self.read_meta_item(
-        #     "Eurotherm 1: {self.meta[self.eurotherm1_key][0]:.05f} {self.meta[self.eurotherm1_key][1]}")
+        descr += self.read_meta_item(
+            "Furnace temperature: {self.meta[self.eurotherm1_key][0]:.02f} {self.meta[self.eurotherm1_key][1]}")
         # descr += self.read_meta_item(
         #     "Eurotherm 2: {self.meta[self.eurotherm2_key][0]:.05f} {self.meta[self.eurotherm2_key][1]}")
 
@@ -145,12 +145,12 @@ class TomoLog2BM(TomoLog):
     def publish_proj(self, presentation_id, page_id, proj):
         # 2-BM datasets may include both microCT data and a web camera image
         self.google_slide.create_textbox_with_text(
-            presentation_id, page_id, 'Micro-CT projection', 90, 20, 10, 155, 8, 0)
+            presentation_id, page_id, 'Micro-CT projection', 90, 20, 10, 167, 8, 0)
         self.plot_projection(proj[0], self.file_name_proj0)
         proj_url = cloud.upload(self.args, self.file_name_proj0)
         log.info('Publish microCT projection')
         self.google_slide.create_image(
-            presentation_id, page_id, proj_url, 170, 170, 0, 145)
+            presentation_id, page_id, proj_url, 170, 170, 0, 190)
         if len(proj) > 1:
             self.google_slide.create_textbox_with_text(
                 presentation_id, page_id, 'Frame from the IP camera in the hutch', 160, 20, 10, 290, 8, 0)


### PR DESCRIPTION
## Changes

1. **`feat: auto-detect h5/tiff recon layout; rec_line for h5; show presentation-url at end`**
   - New `_recon_layout()` helper inspects the filesystem and picks `h5` (single `<base>_rec.h5` file) or `tiff` (per-dataset `<base>_rec/` folder) automatically. `--save-format auto` is the new default; explicit `tiff` / `h5` / `h5nolinks` still work.
   - `read_rec_line()` now finds the CLI log under both layouts (`<rec_dir>/<base>_rec_line.txt` for h5, `<rec_dir>/<base>_rec/rec_line.txt` for tiff).
   - Fixed the h5 branch of `read_recon()` which was reading `/exchange/recon` (tomocupy actually writes `/exchange/data`) and never assigning `recon = [x, y, z]` or `self.binning_rec` — that branch was silently broken before.
   - Adds a final `presentation-url: <url>` log line so users see the deck URL at the end of every batch.

2. **`feat: add --analysis-path flag to override recon directory location`**
   - New `--analysis-path PATH` CLI flag for cases where raw data and reconstructions live in different directory trees (e.g. raw at `/gdata/<beamtime>/data/`, recons at `/gdata/<beamtime>/analysis/`). Default behavior unchanged (`<dirname_of_raw>_rec/`).
   - All layout code routes through a `_rec_dir()` helper for a single source of truth.

3. **`fix(main): catch per-file exceptions in directory mode so batch survives failures`**
   - Wraps each per-file call in `run_log()`'s directory-iteration loop with `try`/`except Exception as e`. A transient imgur 500 or any other single-dataset crash now logs `Failed to publish <name>: <error> — continuing batch` instead of killing the whole multi-hour run.

4. **`feat(2bm): add Furnace temperature metadata bullet and lower projection to clear it`**
   - Uncomments the eurotherm1 thermocouple bullet (was previously disabled) and re-labels as "Furnace temperature" for clarity.
   - The extra metadata row pushed the bullet box into the projection image, so the projection is lowered (image y 145→190, title y 155→167) to keep the layout clean.

## Backward compatibility

- Default `--save-format` flipped from `tiff` to `auto`. Anyone who scripted `--save-format tiff` explicitly is unaffected; anyone who relied on the implicit `tiff` default now gets auto-detection, which produces the right answer in both layouts on disk.
- The `--analysis-path` flag is optional; omitting it preserves the existing behavior of looking under `<dirname_of_raw>_rec/`.
- Try/except around per-file calls only catches what would have crashed the batch anyway; no behavior change for runs that don't hit errors.

## Test plan

- [ ] `tomolog run --file-name <raw.h5>` with the tiff layout works (existing path).
- [ ] `tomolog run --file-name <raw.h5>` with an h5nolinks recon at the default location auto-detects it.
- [ ] `tomolog run --file-name <raw.h5> --analysis-path /gdata/.../analysis/` finds the recon and rec_line.txt under that override path.
- [ ] `tomolog run --file-name <dir>/` iterates over all `*.h5` and continues past any single-file failure (verify with a directory containing one intentionally-broken h5).
- [ ] 2-BM slides show a "Furnace temperature: X.XX degC" bullet when the eurotherm1 thermocouple key is present in the h5.
- [ ] Final log line of every run is `presentation-url: <url>`.