### PR TITLE
tomolog: fall back to h5 attribute when _rec_line.txt is missing

### DIFF
--- a/src/tomolog_cli/tomolog.py
+++ b/src/tomolog_cli/tomolog.py
@@ -198,11 +198,26 @@ class TomoLog():
             rec_dir = self._rec_dir()
             layout = self._recon_layout()
             if layout == 'h5':
-                path = f'{rec_dir}/{basename}_rec_line.txt'
+                txt_path = f'{rec_dir}/{basename}_rec_line.txt'
+                h5_path = f'{rec_dir}/{basename}_rec.h5'
+                if os.path.exists(txt_path):
+                    with open(txt_path, 'r') as fid:
+                        line = fid.readlines()[0]
+                else:
+                    # Newer tomocupy runs no longer write the sidecar txt for h5
+                    # output: the command line is stored as an attribute of
+                    # /exchange/data. Fall back to reading it from the h5 file.
+                    with h5py.File(h5_path, 'r') as fid:
+                        cmd = fid['exchange/data'].attrs.get('command', '')
+                        if isinstance(cmd, bytes):
+                            cmd = cmd.decode('utf-8')
+                        elif hasattr(cmd, 'decode'):
+                            cmd = cmd.decode('utf-8')
+                        line = str(cmd)
             else:
                 path = f'{rec_dir}/{basename}_rec/rec_line.txt'
-            with open(path, 'r') as fid:
-                line = fid.readlines()[0]
+                with open(path, 'r') as fid:
+                    line = fid.readlines()[0]
         except:
             log.warning('Skipping the command line for reconstruction')
             line = ''


### PR DESCRIPTION
Newer tomocupy runs (h5 / h5nolinks output) no longer write the _rec_line.txt sidecar because the reconstruction command is already stored as the `command` attribute on /exchange/data. read_rec_line() previously opened the sidecar unconditionally and, on failure, logged "Skipping the command line for reconstruction" and dropped the information from the report.

For the h5 layout branch, read the sidecar txt when it is present (preserves backward-compat with older reconstructions that only have the txt) and otherwise fall back to reading the `command` attribute from <base>_rec.h5. The tiff-layout branch is unchanged: tiff outputs have no h5 container to fall back to.

Verified against Sample_A_0_021_rec.h5: the byte-string retrieved from /exchange/data.attrs[command] is identical (403 chars) to the sidecar txt produced by the same run.