### PR TITLE
Add pyproject.toml to enable PEP 517/660 builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=64", "wheel"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Modern pip (>=21.3) prefers a declared PEP 517 build backend. Without a pyproject.toml, pip falls back to `setup.py develop` for editable installs, which invokes easy_install-era code paths that try to reach PyPI even when --no-deps is passed. On air-gapped or private-network machines (e.g. tomo4) that hangs indefinitely.

Adding a minimal pyproject.toml selecting the setuptools build_meta backend routes editable installs through the modern PEP 660 path, which does not touch the network. setup.py is untouched — setuptools still reads it during the build — so the existing package layout, entry_points, and version handling continue to work.

Requires setuptools>=64 (needed for PEP 660 editable install support).