### PR TITLE
fix(2-BM): remove globus option and display correct sample vertical position

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -10,7 +10,7 @@ To publish experiment log information to a google page::
 For help::
 
    $ tomolog run -h
-   usage: tomolog run [-h] [--beamline {None,2-bm,7-bm,32-id}] [--doc-dir DOC_DIR] [--file-name PATH] [--cloud-service {imgur,globus}] [--count COUNT] [--max MAX]
+   usage: tomolog run [-h] [--beamline {None,2-bm,7-bm,32-id}] [--doc-dir DOC_DIR] [--file-name PATH] [--cloud-service {imgur,aps}] [--count COUNT] [--max MAX]
                       [--min MIN] [--presentation-url PRESENTATION_URL] [--config FILE] [--config-update] [--idx IDX]
                       [--idy IDY] [--idz IDZ] [--logs-home FILE] [--magnification MAGNIFICATION] [--nproc NPROC] [--pixel-size PIXEL_SIZE] [--public]
                       [--save-format {tiff,h5}] [--token-home FILE] [--verbose] [--zoom ZOOM]
@@ -22,7 +22,7 @@ For help::
      --doc-dir DOC_DIR     sphinx/readthedocs documentation directory where the meta data table extracted from the hdf5 file should be saved, e.g. docs/source/...
                            (default: .)
      --file-name PATH      Name of the hdf file (default: .)
-     --cloud-service {imgur,globus}
+     --cloud-service {imgur,aps}
                            cloud service where generated images will be uploaded. Google API retrieves images by url before publishing on slides (default: imgur)
      --count COUNT         counter is incremented at each google slide generated. Conter is appended to the url to generate a unique url as required by some
                            service (default: 0)

--- a/src/tomolog_cli/cloud.py
+++ b/src/tomolog_cli/cloud.py
@@ -109,11 +109,6 @@ def upload(args, filename):
             traceback.print_exc()
         except Exception as e:
             traceback.print_exc()
-    elif args.cloud_service == 'globus':
-        log.info('Uploading image to globus')
-        log.error('Cloud Serice: %s is not implemented yet' % args.cloud_service)
-        exit()
-
     args.count = args.count + 1
     return url
 

--- a/src/tomolog_cli/config.py
+++ b/src/tomolog_cli/config.py
@@ -212,7 +212,7 @@ SECTIONS['parameters'] = {
         'default': 'imgur',
         'type': str,
         'help': "cloud service where generated images will be uploaded. Google API retrieves images by url before publishing on slides",
-        'choices': ['imgur','globus', 'aps']},    
+        'choices': ['imgur', 'aps']},
     'count': {
         'type': int,
         'default': 0,

--- a/src/tomolog_cli/tomolog_2bm.py
+++ b/src/tomolog_cli/tomolog_2bm.py
@@ -79,7 +79,7 @@ class TomoLog2BM(TomoLog):
         super().__init__(args)
         # add here beamline specific keys
         self.energy_key               = '/measurement/instrument/monochromator/energy'
-        self.sample_y_key             = '/measurement/instrument/sample_motor_stack/setup/y'
+        self.sample_y_key             = '/measurement/instrument/sample_motor_stack/setup/hexapod_y'
         self.sample_pitch_angle_key   = '/measurement/instrument/sample_motor_stack/setup/pitch'
         self.propogation_distance_key = '/measurement/instrument/detector_motor_stack/setup/z'
         self.load_key                 = '/measurement/sample/environment/load_cell/load_raw'


### PR DESCRIPTION
**Summary**

- Remove globus as a cloud-service option (e285ef3): Globus was never implemented — the stub logged an error and exited. Drop the dead branch from cloud.py, remove globus from the choices list in config.py, and update usage.rst accordingly. Valid options are now imgur and aps.
- Display hexapod Y RBV as sample vertical position (153e932): Switch sample_y_key from setup/y ($(TS)SampleInY, always 0 for single scans) to setup/hexapod_y (2bmHXP:m3.RBV, actual motor readback). Requires areadetector XML changes in decarlof/dxfile@a540d0b. Files acquired before the next IOC restart will silently skip the Sample Y bullet; files after will show the correct value.

**Files changed**

- src/tomolog_cli/cloud.py
- src/tomolog_cli/config.py
- src/tomolog_cli/tomolog_2bm.py
- docs/source/usage.rst