### PR TITLE
fix: scalebar in h5 recon and suppress furnace bullet when no furnace

### DIFF
--- a/src/tomolog_cli/tomolog.py
+++ b/src/tomolog_cli/tomolog.py
@@ -345,9 +345,9 @@ class TomoLog():
                     if self.args.idx == -1:
                         self.args.idx = int(w//2)
                     if self.double_fov == True:
-                        binning_rec = np.log2(width//(w//2))
+                        binning_rec = width // (w // 2)
                     else:
-                        binning_rec = np.log2(width//(w))
+                        binning_rec = width // w
                     x = data[:, :, self.args.idx]
                     y = data[:, self.args.idy]
                     z = data[self.args.idz]

--- a/src/tomolog_cli/tomolog_2bm.py
+++ b/src/tomolog_cli/tomolog_2bm.py
@@ -102,8 +102,8 @@ class TomoLog2BM(TomoLog):
             "Sample Y: {self.meta[self.sample_y_key][0]:.02f} {self.meta[self.sample_y_key][1]}")
         descr += self.read_meta_item(
             "Propagation dist.: {self.meta[self.propogation_distance_key][0]:.02f} {self.meta[self.propogation_distance_key][1]}")
-        descr += self.read_meta_item(
-            "Furnace temperature: {self.meta[self.eurotherm1_key][0]:.02f} {self.meta[self.eurotherm1_key][1]}")
+        # descr += self.read_meta_item(
+        #     "Furnace temperature: {self.meta[self.eurotherm1_key][0]:.02f} {self.meta[self.eurotherm1_key][1]}")
         # descr += self.read_meta_item(
         #     "Eurotherm 2: {self.meta[self.eurotherm2_key][0]:.05f} {self.meta[self.eurotherm2_key][1]}")
 


### PR DESCRIPTION
## Summary

- **Fix scalebar invisible in h5 reconstruction images**: `binning_rec` was stored as `np.log2(width/w)`, so for unbinned reconstructions `log2(1) = 
0`, making the scalebar dx = 0 and invisible. Now stored as the actual integer factor `width // w`, consistent with the tiff path.
- **Comment out furnace temperature bullet (2-BM)**: Not all users have a furnace; the bullet was showing `nan °C` for regular scans.

## Test plan

- [ ] Run `tomolog` on a 2-BM h5 reconstruction with no binning and verify scalebar is visible
- [ ] Run `tomolog` on a 2-BM scan without a furnace and verify no furnace bullet appears on the slide
