### PR TITLE
Faster h5 recon reads; --path CLI alias

### DIFF
--- a/src/tomolog_cli/config.py
+++ b/src/tomolog_cli/config.py
@@ -187,7 +187,8 @@ SECTIONS['file-reading'] = {
     'file-name': {
         'default': '.',
         'type': Path,
-        'help': "Name of the hdf file",
+        'aliases': ['--path'],
+        'help': "Path to an hdf file, or a directory of hdf files to batch-publish",
         'metavar': 'PATH'},
     'doc-dir': {
         'type': str,
@@ -295,8 +296,9 @@ class Params(object):
     def add_parser_args(self, parser):
         for section in self.sections:
             for name in sorted(SECTIONS[section]):
-                opts = SECTIONS[section][name]
-                parser.add_argument('--{}'.format(name), **opts)
+                opts = dict(SECTIONS[section][name])
+                aliases = opts.pop('aliases', ())
+                parser.add_argument('--{}'.format(name), *aliases, **opts)
 
     def add_arguments(self, parser):
         self.add_parser_args(parser)

--- a/src/tomolog_cli/tomolog.py
+++ b/src/tomolog_cli/tomolog.py
@@ -338,19 +338,42 @@ class TomoLog():
                 with h5py.File(fname, 'r') as fid:
                     data = fid['exchange/data']
                     h, w = data.shape[:2]
+                    w2 = data.shape[2]
                     if self.args.idz == -1:
                         self.args.idz = int(h//2)
                     if self.args.idy == -1:
                         self.args.idy = int(w//2)
                     if self.args.idx == -1:
-                        self.args.idx = int(w//2)
+                        self.args.idx = int(w2//2)
                     if self.double_fov == True:
                         binning_rec = width // (w // 2)
                     else:
                         binning_rec = width // w
-                    x = data[:, :, self.args.idx]
-                    y = data[:, self.args.idy]
-                    z = data[self.args.idz]
+
+                    # Stream through z in bounded-memory chunks and extract
+                    # all three cross-sections in one pass. The old code did
+                    # data[:, :, idx] / data[:, idy] / data[idz] as three
+                    # separate slices; each cross-cut the z-primary chunking
+                    # and forced h5py to rescan the whole file, taking >10 min
+                    # on bin1 volumes.
+                    dtype = data.dtype
+                    idx, idy, idz = self.args.idx, self.args.idy, self.args.idz
+                    bytes_per_slice = int(w) * int(w2) * dtype.itemsize
+                    chunk_z = max(1, (256 * 1024 * 1024) // bytes_per_slice)
+                    if data.chunks is not None:
+                        chunk_z = max(chunk_z, data.chunks[0])
+                    x = np.empty((h, w), dtype=dtype)
+                    y = np.empty((h, w2), dtype=dtype)
+                    z = None
+                    for zs in range(0, h, chunk_z):
+                        ze = min(zs + chunk_z, h)
+                        block = data[zs:ze, :, :]
+                        x[zs:ze] = block[:, :, idx]
+                        y[zs:ze] = block[:, idy, :]
+                        if zs <= idz < ze:
+                            z = block[idz - zs].copy()
+                    if z is None:
+                        z = data[idz]
                 recon = [x, y, z]
                 self.binning_rec = binning_rec
             except FileNotFoundError:


### PR DESCRIPTION
 ## Summary
  - `read_recon` (h5 branch) now streams the volume in bounded-memory z-chunks (~256 MB, aligned to native chunking) and extracts the x / y / z cross-sections in a single pass. The previous code took three cross-cutting slices that each forced h5py to rescan the entire z-primary volume. Observed drop from >10 min to ~1 min on a bin1 recon at 2-BM.
  - `config.Params.add_parser_args` now honors an optional `aliases` key on each `SECTIONS` entry and forwards it to `argparse.add_argument`. `--file-name` gets `--path` as an alias, and its help text notes that a directory is also accepted (batch mode).

  ## Test plan
  - [x] `tomolog run --path <file.h5>` publishes a single dataset (2-BM, bin1 h5 recon) and finishes with `Read reconstruction → next log line` in ~1 min instead of ~10.
  - [x] `tomolog run --path <dir>/` iterates every `.h5` in the directory (existing batch path — unchanged).
  - [x] `tomolog run --file-name <file.h5>` still works (alias, not replacement).
  - [x] Rendered reconstruction slide looks identical to a pre-patch run.
